### PR TITLE
allow use of any Drawable for the errorDrawable

### DIFF
--- a/ignition-support/ignition-support-lib/src/main/java/com/github/ignition/support/images/remote/RemoteImageLoaderHandler.java
+++ b/ignition-support/ignition-support-lib/src/main/java/com/github/ignition/support/images/remote/RemoteImageLoaderHandler.java
@@ -67,11 +67,11 @@ public class RemoteImageLoaderHandler extends Handler {
         // the thread will set the image only if it's the right position,
         // otherwise it won't do anything.
         String forUrl = (String) imageView.getTag();
-        if (bitmap == null && errorDrawable != null) {
-            bitmap = ((BitmapDrawable) errorDrawable).getBitmap();
-        }
-        if (bitmap != null && imageUrl.equals(forUrl)) {
-            imageView.setImageBitmap(bitmap);
+        if (imageUrl.equals(forUrl)) {
+            if (bitmap == null)
+                imageView.setImageDrawable(errorDrawable);
+            else
+                imageView.setImageBitmap(bitmap);
 
             // remove the image URL from the view's tag
             imageView.setTag(null);


### PR DESCRIPTION
The code currently throws a `ClassCastException` if the `errorDrawable` is anything other than a `BitmapDrawable`, but there's no particular reason that I can see for this requirement. There are places in our UI where a `ColorDrawable` makes more sense; this patch fixes the issue.
