### PR TITLE
Added catch for OutOfMemoryError when creating Bitmap from cached image data

### DIFF
--- a/ignition-support/ignition-support-lib/src/main/java/com/github/ignition/support/cache/ImageCache.java
+++ b/ignition-support/ignition-support-lib/src/main/java/com/github/ignition/support/cache/ImageCache.java
@@ -69,7 +69,11 @@ public class ImageCache extends AbstractCache<String, byte[]> {
         if (imageData == null) {
             return null;
         }
-        return BitmapFactory.decodeByteArray(imageData, 0, imageData.length);
+        try {
+            return BitmapFactory.decodeByteArray(imageData, 0, imageData.length);
+        } catch (OutOfMemoryError e) {
+            return null;
+        }
     }
 
     @Override


### PR DESCRIPTION
My app users have reported crashes from ImageCache.java:72, when creating Bitmap from cached image data.

I added a catch that just returns null so that the app doesn't crash and shows the error image instead.

Only changed code around row 72, don't know why the complete file looks diffed.
