### PR TITLE
Add null checks to support empty response body

### DIFF
--- a/ignition-support/ignition-support-lib/src/main/java/com/github/ignition/support/http/IgnitedHttpRequestBase.java
+++ b/ignition-support/ignition-support-lib/src/main/java/com/github/ignition/support/http/IgnitedHttpRequestBase.java
@@ -167,7 +167,7 @@ public abstract class IgnitedHttpRequestBase implements IgnitedHttpRequest,
 
         IgnitedHttpResponse bhttpr = new IgnitedHttpResponseImpl(response);
         HttpResponseCache responseCache = ignitedHttp.getResponseCache();
-        if (responseCache != null) {
+        if (responseCache != null && bhttpr.getResponseBody() != null) {
             ResponseData responseData = new ResponseData(status, bhttpr.getResponseBodyAsBytes());
             responseCache.put(getRequestUrl(), responseData);
         }

--- a/ignition-support/ignition-support-lib/src/main/java/com/github/ignition/support/http/IgnitedHttpResponseImpl.java
+++ b/ignition-support/ignition-support-lib/src/main/java/com/github/ignition/support/http/IgnitedHttpResponseImpl.java
@@ -43,16 +43,22 @@ public class IgnitedHttpResponseImpl implements IgnitedHttpResponse {
 
     @Override
     public InputStream getResponseBody() throws IOException {
+    	if(entity == null)
+    		return null;
         return entity.getContent();
     }
 
     @Override
     public byte[] getResponseBodyAsBytes() throws IOException {
+    	if(entity == null)
+    		return null;
         return EntityUtils.toByteArray(entity);
     }
 
     @Override
     public String getResponseBodyAsString() throws IOException {
+    	if(entity == null)
+    		return null;
         return EntityUtils.toString(entity);
     }
 


### PR DESCRIPTION
Needed to support 304 Not Modified responses received when using If-None-Match header with etags. 
