### PR TITLE
Extended RemoteImageLoader to support downloading images to use as Textview's CompoundDrawables.

### DIFF
--- a/ignition-core/ignition-core-lib/src/com/github/ignition/core/widgets/RemoteImageView.java
+++ b/ignition-core/ignition-core-lib/src/com/github/ignition/core/widgets/RemoteImageView.java
@@ -282,8 +282,9 @@ public class RemoteImageView extends ImageView {
             boolean wasUpdated = super.handleImageLoaded(bitmap, msg);
             if (wasUpdated) {
                 state = STATE_LOADED;
-                if(listener != null)
-                	listener.onImageLoaded(bitmap);
+                if (listener != null) {
+                    listener.onImageLoaded(bitmap);
+                }
                 showProgressView(false);
             }
             return wasUpdated;
@@ -339,19 +340,19 @@ public class RemoteImageView extends ImageView {
     public View getProgressView() {
         return progressViewContainer.getChildAt(0);
     }
-    
+
     public static interface RemoteImageViewListener {
-    	public void onImageLoaded(Bitmap bm);
-    }    
-    
+        public void onImageLoaded(Bitmap bm);
+    }
+
     /**
      * Use this method to set a listener for events raised by the remote image view such as image
      * loaded.
      * 
      * @param listener
-     * 			  an implementation of the {@link RemoteImageViewListener} interface
+     *            an implementation of the {@link RemoteImageViewListener} interface
      */
     public void setRemoteImageViewListener(RemoteImageViewListener listener) {
-    	this.listener = listener;
+        this.listener = listener;
     }
 }

--- a/ignition-support/ignition-support-lib/src/main/java/com/github/ignition/support/images/remote/RemoteImageLoader.java
+++ b/ignition-support/ignition-support-lib/src/main/java/com/github/ignition/support/images/remote/RemoteImageLoader.java
@@ -54,7 +54,7 @@ public class RemoteImageLoader {
 
     private Drawable defaultDummyDrawable, errorDrawable;
 
-    private RemoteImageLoaderHandler handler;
+    private RemoteImageLoaderHandler imageLoaderHandler;
 
     public RemoteImageLoader(Context context) {
         this(context, true);
@@ -117,7 +117,7 @@ public class RemoteImageLoader {
 
     public void setDownloadFailedDrawable(Drawable errorDrawable) {
         this.errorDrawable = errorDrawable;
-        handler.setErrorDrawable(errorDrawable);
+        imageLoaderHandler.setErrorDrawable(errorDrawable);
     }
 
     public void setImageCache(ImageCache imageCache) {
@@ -267,8 +267,8 @@ public class RemoteImageLoader {
     }
 
     public void loadImage(Drawable dummyDrawable, RemoteImageLoaderHandler handler) {
-        this.handler = handler;
-        RemoteImageLoaderViewAdapter remoteImageLoaderViewAdapter = handler
+        this.imageLoaderHandler = handler;
+        RemoteImageLoaderViewAdapter remoteImageLoaderViewAdapter = imageLoaderHandler
                 .getRemoteImageLoaderViewAdapter();
         String imageUrl = remoteImageLoaderViewAdapter.getImageUrl();
         View view = remoteImageLoaderViewAdapter.getView();
@@ -297,10 +297,10 @@ public class RemoteImageLoader {
 
         if (imageCache != null && imageCache.containsKeyInMemory(imageUrl)) {
             // do not go through message passing, handle directly instead
-            handler.handleImageLoaded(imageCache.getBitmap(imageUrl), null);
+            imageLoaderHandler.handleImageLoaded(imageCache.getBitmap(imageUrl), null);
         } else {
-            executor.execute(new RemoteImageLoaderJob(imageUrl, handler, imageCache, numRetries,
-                    defaultBufferSize));
+            executor.execute(new RemoteImageLoaderJob(imageUrl, imageLoaderHandler, imageCache,
+                    numRetries, defaultBufferSize));
         }
     }
 }

--- a/ignition-support/ignition-support-lib/src/main/java/com/github/ignition/support/images/remote/RemoteImageLoader.java
+++ b/ignition-support/ignition-support-lib/src/main/java/com/github/ignition/support/images/remote/RemoteImageLoader.java
@@ -263,6 +263,8 @@ public class RemoteImageLoader {
     @Deprecated
     public void loadImage(String imageUrl, ImageView view, Drawable dummyDrawable,
             RemoteImageLoaderHandler handler) {
+        handler.setImageUrl(imageUrl);
+        handler.setView(view);
         loadImage(dummyDrawable, handler);
     }
 

--- a/ignition-support/ignition-support-lib/src/main/java/com/github/ignition/support/images/remote/RemoteImageLoader.java
+++ b/ignition-support/ignition-support-lib/src/main/java/com/github/ignition/support/images/remote/RemoteImageLoader.java
@@ -229,9 +229,10 @@ public class RemoteImageLoader {
     }
 
     /**
-     * Triggers the image loader for the given image and view. The image loading will be performed
-     * concurrently to the UI main thread, using a fixed size thread pool. The loaded image will be
-     * posted back to the given ImageView upon completion.
+     * @deprecated Use {@link RemoteImageLoader#loadImage(RemoteImageLoaderHandler)} instead.
+     *             Triggers the image loader for the given image and view. The image loading will be
+     *             performed concurrently to the UI main thread, using a fixed size thread pool. The
+     *             loaded image will be posted back to the given ImageView upon completion.
      * 
      * @param imageUrl
      *            the URL of the image to download
@@ -246,10 +247,11 @@ public class RemoteImageLoader {
     }
 
     /**
-     * Triggers the image loader for the given image and view. The image loading will be performed
-     * concurrently to the UI main thread, using a fixed size thread pool. The loaded image will be
-     * posted back to the given ImageView upon completion. While waiting, the dummyDrawable is
-     * shown.
+     * @deprecated Use {@link RemoteImageLoader#loadImage(Drawable, RemoteImageLoaderHandler)}
+     *             instead. Triggers the image loader for the given image and view. The image
+     *             loading will be performed concurrently to the UI main thread, using a fixed size
+     *             thread pool. The loaded image will be posted back to the given ImageView upon
+     *             completion. While waiting, the dummyDrawable is shown.
      * 
      * @param imageUrl
      *            the URL of the image to download
@@ -268,6 +270,30 @@ public class RemoteImageLoader {
         loadImage(dummyDrawable, handler);
     }
 
+    /**
+     * Triggers the image loader for the given handler. The image loading will be performed
+     * concurrently to the UI main thread, using a fixed size thread pool. The loaded image will be
+     * posted back to the given ImageView upon completion. While waiting, the dummyDrawable is
+     * shown.
+     * 
+     * @param handler
+     *            the handler that will process the bitmap after completion
+     **/
+    public void loadImage(RemoteImageLoaderHandler handler) {
+        loadImage(defaultDummyDrawable, handler);
+    }
+
+    /**
+     * Triggers the image loader for the given handler. The image loading will be performed
+     * concurrently to the UI main thread, using a fixed size thread pool. The loaded image will be
+     * posted back to the given ImageView upon completion. While waiting, the dummyDrawable is
+     * shown.
+     * 
+     * @param dummyDrawable
+     *            the Drawable to be shown while the image is being downloaded.
+     * @param handler
+     *            the handler that will process the bitmap after completion
+     **/
     public void loadImage(Drawable dummyDrawable, RemoteImageLoaderHandler handler) {
         this.imageLoaderHandler = handler;
         RemoteImageLoaderViewAdapter remoteImageLoaderViewAdapter = imageLoaderHandler

--- a/ignition-support/ignition-support-lib/src/main/java/com/github/ignition/support/images/remote/RemoteImageLoaderHandler.java
+++ b/ignition-support/ignition-support-lib/src/main/java/com/github/ignition/support/images/remote/RemoteImageLoaderHandler.java
@@ -115,6 +115,14 @@ public class RemoteImageLoaderHandler extends Handler {
         remoteImageLoaderViewAdapter.setErrorDrawable(errorDrawable);
     }
 
+    public View getView() {
+        return remoteImageLoaderViewAdapter.getView();
+    }
+
+    public void setView(View view) {
+        remoteImageLoaderViewAdapter.setView(view);
+    }
+
     @Deprecated
     public ImageView getImageView() {
         return imageView;
@@ -181,7 +189,11 @@ public class RemoteImageLoaderHandler extends Handler {
             return errorDrawable;
         }
 
-        protected View getView() {
+        public void setView(View view) {
+            this.view = view;
+        }
+
+        public View getView() {
             return view;
         }
 

--- a/ignition-support/ignition-support-lib/src/main/java/com/github/ignition/support/images/remote/RemoteImageLoaderHandler.java
+++ b/ignition-support/ignition-support-lib/src/main/java/com/github/ignition/support/images/remote/RemoteImageLoaderHandler.java
@@ -21,6 +21,7 @@ import android.os.Bundle;
 import android.os.Handler;
 import android.os.Looper;
 import android.os.Message;
+import android.view.View;
 import android.widget.ImageView;
 
 public class RemoteImageLoaderHandler extends Handler {
@@ -29,27 +30,38 @@ public class RemoteImageLoaderHandler extends Handler {
     public static final String BITMAP_EXTRA = "ign:extra_bitmap";
     public static final String IMAGE_URL_EXTRA = "ign:extra_image_url";
 
+    @Deprecated
     private ImageView imageView;
-    private String imageUrl;
-    private Drawable errorDrawable;
+    private RemoteImageLoaderViewAdapter remoteImageLoaderViewAdapter;
 
+    @Deprecated
     public RemoteImageLoaderHandler(ImageView imageView, String imageUrl, Drawable errorDrawable) {
         this.imageView = imageView;
-        this.imageUrl = imageUrl;
-        this.errorDrawable = errorDrawable;
         init(imageView, imageUrl, errorDrawable);
     }
 
+    @Deprecated
     public RemoteImageLoaderHandler(Looper looper, ImageView imageView, String imageUrl,
             Drawable errorDrawable) {
         super(looper);
         init(imageView, imageUrl, errorDrawable);
     }
 
+    @Deprecated
     private void init(ImageView imageView, String imageUrl, Drawable errorDrawable) {
         this.imageView = imageView;
-        this.imageUrl = imageUrl;
-        this.errorDrawable = errorDrawable;
+        this.remoteImageLoaderViewAdapter = new RemoteImageLoaderImageViewAdapter(imageUrl,
+                imageView, errorDrawable);
+    }
+
+    public RemoteImageLoaderHandler(RemoteImageLoaderViewAdapter imageLoaderViewAdapter) {
+        remoteImageLoaderViewAdapter = imageLoaderViewAdapter;
+    }
+
+    public RemoteImageLoaderHandler(Looper looper,
+            RemoteImageLoaderViewAdapter imageLoaderViewAdapter) {
+        super(looper);
+        remoteImageLoaderViewAdapter = imageLoaderViewAdapter;
     }
 
     @Override
@@ -76,38 +88,71 @@ public class RemoteImageLoaderHandler extends Handler {
      * @return true if the view was updated with the new image, false if it was discarded
      */
     protected boolean handleImageLoaded(Bitmap bitmap, Message msg) {
-        // If this handler is used for loading images in a ListAdapter,
-        // the thread will set the image only if it's the right position,
-        // otherwise it won't do anything.
-        Object viewTag = imageView.getTag();
-        if (imageUrl.equals(viewTag)) {
-            if (bitmap == null)
-                imageView.setImageDrawable(errorDrawable);
-            else
-                imageView.setImageBitmap(bitmap);
-
-            // remove the image URL from the view's tag
-            imageView.setTag(null);
-
-            return true;
+        if (remoteImageLoaderViewAdapter == null) {
+            throw new IllegalStateException("A RemoteImageLoaderViewAdapter must be set!");
         }
-
-        return false;
+        return remoteImageLoaderViewAdapter.handleImageLoaded(bitmap, msg);
     }
 
     public String getImageUrl() {
-        return imageUrl;
+        return remoteImageLoaderViewAdapter.getImageUrl();
     }
 
     public void setImageUrl(String imageUrl) {
-        this.imageUrl = imageUrl;
+        remoteImageLoaderViewAdapter.setImageUrl(imageUrl);
     }
 
+    @Deprecated
     public ImageView getImageView() {
         return imageView;
     }
 
+    @Deprecated
     public void setImageView(ImageView imageView) {
         this.imageView = imageView;
+    }
+
+    public RemoteImageLoaderViewAdapter getRemoteImageLoaderViewAdapter() {
+        return remoteImageLoaderViewAdapter;
+    }
+
+    public void setRemoteImageLoaderViewAdapter(
+            RemoteImageLoaderViewAdapter remoteImageLoaderViewAdapter) {
+        this.remoteImageLoaderViewAdapter = remoteImageLoaderViewAdapter;
+    }
+
+    public static class RemoteImageLoaderViewAdapter {
+        protected View view;
+        protected Drawable errorDrawable;
+        protected String imageUrl;
+
+        public RemoteImageLoaderViewAdapter(String imageUrl, View view, Drawable errorDrawable) {
+            this.imageUrl = imageUrl;
+            this.view = view;
+            this.errorDrawable = errorDrawable;
+        }
+
+        protected boolean handleImageLoaded(Bitmap bitmap, Message msg) {
+            return false;
+        }
+
+        protected void setDrawable(Drawable drawable) {
+        }
+
+        protected View getView() {
+            return view;
+        }
+
+        public void setImageUrl(String imageUrl) {
+            this.imageUrl = imageUrl;
+        }
+
+        public String getImageUrl() {
+            return imageUrl;
+        }
+
+        public Bitmap processBitmap(Bitmap bitmap) {
+            return bitmap;
+        }
     }
 }

--- a/ignition-support/ignition-support-lib/src/main/java/com/github/ignition/support/images/remote/RemoteImageLoaderImageViewAdapter.java
+++ b/ignition-support/ignition-support-lib/src/main/java/com/github/ignition/support/images/remote/RemoteImageLoaderImageViewAdapter.java
@@ -2,7 +2,6 @@ package com.github.ignition.support.images.remote;
 
 import android.graphics.Bitmap;
 import android.graphics.drawable.Drawable;
-import android.os.Message;
 import android.view.View;
 import android.widget.ImageView;
 
@@ -14,30 +13,18 @@ public class RemoteImageLoaderImageViewAdapter extends
     }
 
     @Override
-    public boolean handleImageLoaded(Bitmap bitmap, Message msg) {
-        // If this handler is used for loading images in a ListAdapter,
-        // the thread will set the image only if it's the right position,
-        // otherwise it won't do anything.
-        Object viewTag = view.getTag();
-        if (imageUrl.equals(viewTag)) {
-            if (bitmap == null) {
-                if (view != null) {
-                    ((ImageView) view).setImageDrawable(errorDrawable);
-                }
-            } else {
-                if (view != null) {
-                    ((ImageView) view).setImageBitmap(processBitmap(bitmap));
-                }
-            }
-            // remove the image URL from the view's tag
-            view.setTag(null);
-            return true;
-        }
-        return false;
+    protected void onImageLoadedFailed() {
+        ((ImageView) view).setImageDrawable(errorDrawable);
     }
 
     @Override
-    public void setDrawable(Drawable drawable) {
+    protected void onImageLoadedSuccess(Bitmap bitmap) {
+        Bitmap processedBitmap = processBitmap(bitmap);
+        ((ImageView) view).setImageBitmap(processedBitmap);
+    }
+
+    @Override
+    public void setDummyDrawableForView(Drawable drawable) {
         ((ImageView) view).setImageDrawable(drawable);
     }
 

--- a/ignition-support/ignition-support-lib/src/main/java/com/github/ignition/support/images/remote/RemoteImageLoaderImageViewAdapter.java
+++ b/ignition-support/ignition-support-lib/src/main/java/com/github/ignition/support/images/remote/RemoteImageLoaderImageViewAdapter.java
@@ -1,0 +1,48 @@
+package com.github.ignition.support.images.remote;
+
+import android.graphics.Bitmap;
+import android.graphics.drawable.Drawable;
+import android.os.Message;
+import android.view.View;
+import android.widget.ImageView;
+
+public class RemoteImageLoaderImageViewAdapter extends
+        RemoteImageLoaderHandler.RemoteImageLoaderViewAdapter {
+
+    public RemoteImageLoaderImageViewAdapter(String imageUrl, View view, Drawable errorDrawable) {
+        super(imageUrl, view, errorDrawable);
+    }
+
+    @Override
+    public boolean handleImageLoaded(Bitmap bitmap, Message msg) {
+        // If this handler is used for loading images in a ListAdapter,
+        // the thread will set the image only if it's the right position,
+        // otherwise it won't do anything.
+        Object viewTag = view.getTag();
+        if (imageUrl.equals(viewTag)) {
+            if (bitmap == null) {
+                if (view != null) {
+                    ((ImageView) view).setImageDrawable(errorDrawable);
+                }
+            } else {
+                if (view != null) {
+                    ((ImageView) view).setImageBitmap(processBitmap(bitmap));
+                }
+            }
+            // remove the image URL from the view's tag
+            view.setTag(null);
+            return true;
+        }
+        return false;
+    }
+
+    @Override
+    public void setDrawable(Drawable drawable) {
+        ((ImageView) view).setImageDrawable(drawable);
+    }
+
+    @Override
+    public ImageView getView() {
+        return (ImageView) view;
+    }
+}

--- a/ignition-support/ignition-support-lib/src/main/java/com/github/ignition/support/images/remote/RemoteImageLoaderTextViewAdapter.java
+++ b/ignition-support/ignition-support-lib/src/main/java/com/github/ignition/support/images/remote/RemoteImageLoaderTextViewAdapter.java
@@ -1,14 +1,16 @@
 package com.github.ignition.support.images.remote;
 
+import android.content.Context;
 import android.graphics.Bitmap;
 import android.graphics.drawable.BitmapDrawable;
 import android.graphics.drawable.Drawable;
-import android.os.Message;
+import android.util.DisplayMetrics;
+import android.view.WindowManager;
 import android.widget.TextView;
 
 import com.github.ignition.support.images.remote.RemoteImageLoaderHandler.RemoteImageLoaderViewAdapter;
 
-// TODO: extend this class so that it can handle more than one drawable.
+// TODO: extend this class so that it can download more than one drawable.
 public class RemoteImageLoaderTextViewAdapter extends RemoteImageLoaderViewAdapter {
     private boolean left, top, right, bottom;
 
@@ -21,30 +23,20 @@ public class RemoteImageLoaderTextViewAdapter extends RemoteImageLoaderViewAdapt
     }
 
     @Override
-    public boolean handleImageLoaded(Bitmap bitmap, Message msg) {
-        Object viewTag = view.getTag();
-        if (imageUrl.equals(viewTag)) {
-            if (bitmap == null) {
-                if (view != null) {
-                    setCompoundDrawable(errorDrawable);
-                }
-            } else {
-                if (view != null) {
-                    Bitmap processedBitmap = processBitmap(bitmap);
-                    Drawable drawable = new BitmapDrawable(processedBitmap);
-                    setCompoundDrawable(drawable);
-                }
-            }
-            // remove the image URL from the view's tag
-            view.setTag(null);
-            return true;
-        }
-        return false;
+    protected void onImageLoadedFailed() {
+        setCompoundDrawable(errorDrawable);
     }
 
     @Override
-    public void setDrawable(Drawable drawable) {
+    protected void onImageLoadedSuccess(Bitmap bitmap) {
+        Bitmap processedBitmap = processBitmap(bitmap);
+        Drawable drawable = new BitmapDrawable(processedBitmap);
         setCompoundDrawable(drawable);
+    }
+
+    @Override
+    public void setDummyDrawableForView(Drawable dummyDrawable) {
+        setCompoundDrawable(dummyDrawable);
     }
 
     @Override
@@ -68,5 +60,4 @@ public class RemoteImageLoaderTextViewAdapter extends RemoteImageLoaderViewAdapt
         ((TextView) view).setCompoundDrawablesWithIntrinsicBounds(leftDrawable, topDrawable,
                 rightDrawable, bottomDrawable);
     }
-
 }

--- a/ignition-support/ignition-support-lib/src/main/java/com/github/ignition/support/images/remote/RemoteImageLoaderTextViewAdapter.java
+++ b/ignition-support/ignition-support-lib/src/main/java/com/github/ignition/support/images/remote/RemoteImageLoaderTextViewAdapter.java
@@ -53,6 +53,14 @@ public class RemoteImageLoaderTextViewAdapter extends RemoteImageLoaderViewAdapt
     }
 
     private void setCompoundDrawable(Drawable drawable) {
+        DisplayMetrics metrics = new DisplayMetrics();
+        ((WindowManager) view.getContext().getSystemService(Context.WINDOW_SERVICE))
+                .getDefaultDisplay().getMetrics(metrics);
+        if (drawable instanceof BitmapDrawable) {
+            // For some reason this must be set explicitly or otherwise the target density will be
+            // wrong.
+            ((BitmapDrawable) drawable).setTargetDensity(metrics.densityDpi);
+        }
         Drawable leftDrawable = left ? drawable : null;
         Drawable topDrawable = top ? drawable : null;
         Drawable rightDrawable = right ? drawable : null;

--- a/ignition-support/ignition-support-lib/src/main/java/com/github/ignition/support/images/remote/RemoteImageLoaderTextViewAdapter.java
+++ b/ignition-support/ignition-support-lib/src/main/java/com/github/ignition/support/images/remote/RemoteImageLoaderTextViewAdapter.java
@@ -1,0 +1,64 @@
+package com.github.ignition.support.images.remote;
+
+import android.graphics.Bitmap;
+import android.graphics.drawable.BitmapDrawable;
+import android.graphics.drawable.Drawable;
+import android.os.Message;
+import android.widget.TextView;
+
+import com.github.ignition.support.images.remote.RemoteImageLoaderHandler.RemoteImageLoaderViewAdapter;
+
+// TODO: extend this class so that it can handle more than one drawable.
+public class RemoteImageLoaderTextViewAdapter extends RemoteImageLoaderViewAdapter {
+    private boolean left, top, right, bottom;
+
+    public RemoteImageLoaderTextViewAdapter(String imageUrl, TextView textView,
+            Drawable errorDrawable, boolean left, boolean top, boolean right, boolean bottom) {
+        super(imageUrl, textView, errorDrawable);
+        this.left = left;
+        this.top = top;
+        this.right = right;
+    }
+
+    @Override
+    public boolean handleImageLoaded(Bitmap bitmap, Message msg) {
+        Object viewTag = view.getTag();
+        if (imageUrl.equals(viewTag)) {
+            if (bitmap == null) {
+                if (view != null) {
+                    setCompoundDrawable(errorDrawable);
+                }
+            } else {
+                if (view != null) {
+                    Bitmap processedBitmap = processBitmap(bitmap);
+                    Drawable drawable = new BitmapDrawable(processedBitmap);
+                    setCompoundDrawable(drawable);
+                }
+            }
+            // remove the image URL from the view's tag
+            view.setTag(null);
+            return true;
+        }
+        return false;
+    }
+
+    @Override
+    public void setDrawable(Drawable drawable) {
+        setCompoundDrawable(drawable);
+    }
+
+    @Override
+    public TextView getView() {
+        return (TextView) view;
+    }
+
+    private void setCompoundDrawable(Drawable drawable) {
+        Drawable leftDrawable = left ? drawable : null;
+        Drawable topDrawable = top ? drawable : null;
+        Drawable rightDrawable = right ? drawable : null;
+        Drawable bottomDrawable = bottom ? drawable : null;
+        ((TextView) view).setCompoundDrawablesWithIntrinsicBounds(leftDrawable, topDrawable,
+                rightDrawable, bottomDrawable);
+    }
+
+}


### PR DESCRIPTION
Current limitation: 
the RemoteImageLoaderTextViewAdapter class supports the download of only one image, ideally it should support downloading up to 4 since a TextView can have up to 4 different CompoundDrawables. If one  sets more than one CompoundDrawable for a TextView, the same drawable will be used.
