### PR TITLE
Allow Executor shutdown for RemoteImageLoader, Do not retry loading bitmap on OutOfMemory

### DIFF
--- a/ignition-support/ignition-support-lib/src/main/java/com/github/ignition/support/images/remote/RemoteImageLoader.java
+++ b/ignition-support/ignition-support-lib/src/main/java/com/github/ignition/support/images/remote/RemoteImageLoader.java
@@ -331,4 +331,10 @@ public class RemoteImageLoader {
                     numRetries, defaultBufferSize));
         }
     }
+    
+    public void destroy() {
+        Log.i("", "shutting down remote image loader");
+        executor.shutdownNow();
+    }
+
 }

--- a/ignition-support/ignition-support-lib/src/main/java/com/github/ignition/support/images/remote/RemoteImageLoaderJob.java
+++ b/ignition-support/ignition-support-lib/src/main/java/com/github/ignition/support/images/remote/RemoteImageLoaderJob.java
@@ -74,6 +74,12 @@ public class RemoteImageLoaderJob implements Runnable {
 
                 return BitmapFactory.decodeByteArray(imageData, 0, imageData.length);
 
+
+            } catch (OutOfMemoryError e) {
+                // do not retry, would make it worse
+                Log.w(LOG_TAG, "download for " + imageUrl + " failed (attempt " + timesTried + ")");
+                return null;
+
             } catch (Throwable e) {
                 Log.w(LOG_TAG, "download for " + imageUrl + " failed (attempt " + timesTried + ")");
                 e.printStackTrace();

--- a/ignition-support/ignition-support-samples/.settings/org.eclipse.core.resources.prefs
+++ b/ignition-support/ignition-support-samples/.settings/org.eclipse.core.resources.prefs
@@ -1,4 +1,3 @@
-#Fri Apr 20 11:08:26 CEST 2012
 eclipse.preferences.version=1
 encoding/<project>=UTF-8
 encoding/src=UTF-8


### PR DESCRIPTION
added possibility to shutdown the executor: new method destroy()
break out of retry mechanism on creating bitmap when OutOfMemory occured
