### PR TITLE
Improvements on picture cache

### DIFF
--- a/ignition-support/ignition-support-lib/src/main/java/com/github/ignition/support/images/remote/RemoteImageLoader.java
+++ b/ignition-support/ignition-support-lib/src/main/java/com/github/ignition/support/images/remote/RemoteImageLoader.java
@@ -326,9 +326,9 @@ public class RemoteImageLoader {
         if (imageCache != null && imageCache.containsKeyInMemory(imageUrl)) {
             // do not go through message passing, handle directly instead
             imageLoaderHandler.handleImageLoaded(imageCache.getBitmap(imageUrl), null);
-        } else {
-            executor.execute(new RemoteImageLoaderJob(imageUrl, imageLoaderHandler, imageCache,
-                    numRetries, defaultBufferSize));
+		} else {
+			executor.execute(new RemoteImageLoaderJob(imageUrl, imageLoaderHandler, imageCache, numRetries, defaultBufferSize,
+					view));
         }
     }
 }

--- a/ignition-support/ignition-support-lib/src/main/java/com/github/ignition/support/images/remote/RemoteImageLoaderHandler.java
+++ b/ignition-support/ignition-support-lib/src/main/java/com/github/ignition/support/images/remote/RemoteImageLoaderHandler.java
@@ -40,6 +40,11 @@ public class RemoteImageLoaderHandler extends Handler {
         init(imageView, imageUrl, errorDrawable);
     }
 
+	public RemoteImageLoaderHandler(RemoteImageLoaderImageViewAdapter remoteImageLoaderImageViewAdapter) {
+		this.imageView = remoteImageLoaderImageViewAdapter.getView();
+		setRemoteImageLoaderViewAdapter(remoteImageLoaderImageViewAdapter);
+	}
+	
     public RemoteImageLoaderHandler(Looper looper, ImageView imageView, String imageUrl,
             Drawable errorDrawable) {
         super(looper);

--- a/ignition-support/ignition-support-lib/src/main/java/com/github/ignition/support/images/remote/RemoteImageLoaderJob.java
+++ b/ignition-support/ignition-support-lib/src/main/java/com/github/ignition/support/images/remote/RemoteImageLoaderJob.java
@@ -49,6 +49,10 @@ public class RemoteImageLoaderJob implements Runnable {
         }
 
         if (bitmap == null) {
+			// If the view is reused do not download the bitmap
+			if (reusableView != null & !imageUrl.equals(reusableView.getTag())) {
+				return;
+			}
             bitmap = downloadImage();
         }
 


### PR DESCRIPTION
Do not download bitmap for reused view.
Do not create a new RemoteImageLoaderImageViewAdapter if you want to use yours.
